### PR TITLE
[WIP] Initial conda support v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ target/
 # pyenv
 .python-version
 
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ matrix:
         env: TOX_ENV=py35
       - python: 3.6
         env: TOX_ENV=py36
-      - python: pypy
-        env: TOX_ENV=pypy
       - python: 3.6
         env: TOX_ENV=flake8
 
 install:
+  - pip install pycosat pyopenssl requests ruamel.yaml
+  - git clone -b master --single-branch --depth 1000 https://github.com/conda/conda.git
+  - pushd conda && pip install . && conda init && popd
+  - conda info
   - pip install tox
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,10 @@ install:
   - "%PYTHON%/Scripts/easy_install -U pip"
   - "%PYTHON%/Scripts/pip install tox"
   - "%PYTHON%/Scripts/pip install wheel"
+  - "%PYTHON%/Scripts/pip install pycosat pyopenssl requests ruamel.yaml"
+  - "git clone -b master --single-branch --depth 1000 https://github.com/conda/conda.git"
+  - "cd conda && pip install . && conda init && cd .."
+  - "conda info"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/tox-dev/tox-conda',
     packages=find_packages(),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=['tox>=3.0.0'],
+    # install_requires=['tox>=3.0.0'],
     entry_points={'tox': ['conda = tox_conda.plugin']},
     license='MIT',
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+from tox._pytestplugin import *  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,0 @@
-from tox._pytestplugin import *  # noqa

--- a/tests/test_tox_conda.py
+++ b/tests/test_tox_conda.py
@@ -1,8 +1,13 @@
-
-
-def test_dummy():
-    """
-    TODO think about how to test this properly
-    TODO check tox own tests to see how to do this (use of _pytestplugin)
-    TODO (also check if someone did this already)
-    """
+def test_skip_unknown_interpreter_result_json(cmd, initproj):
+    initproj("conda-01", filedefs={
+        'tox.ini': '''
+            [tox]
+            envlist=py27,
+            [testenv]
+            deps =
+              itsdangerous
+        '''
+    })
+    result = cmd()
+    assert not result.ret
+    assert "congratulations" in result.out

--- a/tests/test_tox_conda.py
+++ b/tests/test_tox_conda.py
@@ -1,2 +1,4 @@
 def test_success():
     import tox_conda
+
+    del tox_conda

--- a/tests/test_tox_conda.py
+++ b/tests/test_tox_conda.py
@@ -1,13 +1,2 @@
-def test_skip_unknown_interpreter_result_json(cmd, initproj):
-    initproj("conda-01", filedefs={
-        'tox.ini': '''
-            [tox]
-            envlist=py27,
-            [testenv]
-            deps =
-              itsdangerous
-        '''
-    })
-    result = cmd()
-    assert not result.ret
-    assert "congratulations" in result.out
+def test_success():
+    import tox_conda

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ envlist = py27,py34,py35,py36,flake8
 deps =
   pytest
   tox
-
+conda_channels =
+  defaults
+  conda-forge
 commands = pytest --basetemp={envtmpdir} {posargs}
 changedir = tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist = py27,py34,py35,py36,flake8
 deps =
   pytest
   tox
-commands = pytest {posargs:tests}
+commands = pytest {posargs}
+changedir = tests
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist = py27,py34,py35,py36,flake8
 deps =
   pytest
   tox
-commands = pytest {posargs}
+
+commands = pytest --basetemp={envtmpdir} {posargs}
 changedir = tests
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py27,py34,py35,py36,flake8
 [testenv]
 deps =
   pytest
+  tox
 commands = pytest {posargs:tests}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py34,py35,py36,pypy,flake8
+envlist = py27,py34,py35,py36,flake8
 
 [testenv]
-deps = pytest
+deps =
+  pytest
 commands = pytest {posargs:tests}
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
-commands = flake8 tox_plugin.py setup.py tests
+commands = flake8 tox_conda setup.py tests

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -6,7 +6,7 @@ from warnings import warn
 import pluggy
 
 hookimpl = pluggy.HookimplMarker("tox")
-log = logging.getLogger('conda')
+log = logging.getLogger("conda")
 
 
 on_win = bool(sys.platform == "win32")
@@ -14,7 +14,7 @@ on_win = bool(sys.platform == "win32")
 
 @hookimpl
 def tox_get_python_executable(envconfig):
-
+    """Return a python executable for the given python base name."""
     if on_win:
         return os.path.join(envconfig.envdir, "python.exe")
     else:
@@ -25,6 +25,7 @@ def tox_get_python_executable(envconfig):
 
 @hookimpl
 def tox_configure(config):
+    """Called after command line options are parsed and ini-file has been read."""
     envs = config.envlist[:]
     for env in envs:
         envconfig = config.envconfigs[env]
@@ -99,7 +100,7 @@ def which(cmd):
 
 def create_env_yml(envconfig):
     """Create a conda environment.yaml file from an envconfig.
-    
+
     envconfig should contain the following properties:
         - envname
         - channels

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -41,6 +41,10 @@ def tox_configure(config):
     # Directory to store conda files.
     config.conda_workdir = os.path.join(config.toxworkdir, "conda")
 
+    # Override getting python executable.
+    envconfig_class = type(config.envconfigs[config.envlist[0]])
+    envconfig_class.get_envpython = get_conda_python
+
     # Set testenv configurations.
     envs = config.envlist[:]
     for env in envs:
@@ -108,6 +112,10 @@ def tox_testenv_install_deps(venv, action):
     # If created using conda, all pip dependencies are already installed at creation.
     if venv.envconfig.conda:
         return True
+
+
+def get_conda_python(envconfig):
+    return os.path.join(envconfig.envdir, "python")
 
 
 def is_exe(fpath):

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -1,4 +1,7 @@
+import json
 import logging
+import os
+import sys
 
 import pluggy
 
@@ -6,14 +9,92 @@ hookimpl = pluggy.HookimplMarker("tox")
 log = logging.getLogger('conda')
 
 
-@hookimpl
-def tox_addoption(parser):
-    """Add a command line option for later use"""
-    parser.add_argument(
-        '--my-opt', action='store', help='my custom option')
+on_win = bool(sys.platform == "win32")
 
 
 @hookimpl
-def tox_configure(config):
-    """Access your option during configuration"""
-    log.info("my option is: '%s'", config.option.my_opt)
+def tox_testenv_create(venv, action):
+    deps = venv.envconfig.deps
+    conda_deps, pip_deps = split_conda_deps(deps)
+    venv.envconfig.deps = pip_deps
+    venv.envconfig.conda_deps = conda_deps
+
+    # if venv.envconfig.recreate:
+
+    basepython = venv.envconfig.basepython
+    if not basepython.startswith("python"):
+        raise RuntimeError("The conda plugin only supports python basepython.")
+    python_version = basepython[6:]
+    env_location = str(venv.path)
+    args = [
+        '%s' % os.environ["CONDA_EXE"],
+        "install",
+        "--mkdir",
+        "-y",
+        "-p",
+        env_location,
+        "python=%s" % python_version,
+    ]
+    args.extend(str(dep) for dep in conda_deps)
+
+    env = venv._getenv(testcommand=False)
+    redirect = venv.session.config.option.verbose_level < 2
+
+    result = action.popen(args, env=env, redirect=redirect)
+
+    return True if result is None else result
+
+
+@hookimpl
+def tox_runtest_pre(venv):
+    env_var_map = get_activated_env_vars(venv)
+    os.environ.clear()
+    os.environ.update(env_var_map)
+
+
+def get_activated_env_vars(venv):
+    env_location = str(venv.path)
+    cmd_builder = []
+    if on_win:
+        conda_bat = os.environ["CONDA_BAT"]
+        cmd_builder += [
+            "CALL \"{0}\" activate \"{1}\"".format(conda_bat, env_location),
+            "&&",
+            "%CONDA_PYTHON_EXE% -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
+        ]
+    else:
+        conda_exe = os.environ["CONDA_EXE"]
+        cmd_builder += [
+            "sh -c \'"
+            "eval \"$(\"{0}\" shell.posix hook)\"".format(conda_exe),
+            "&&",
+            "conda activate {0}".format(env_location),
+            "&&",
+            "\"$CONDA_PYTHON_EXE\" -c \"import os, json; print(json.dumps(dict(os.environ)))\"",
+            "\'",
+        ]
+
+    cmd = " ".join(cmd_builder)
+    env = venv._getenv(testcommand=False)
+    action = venv.session.newaction(venv, "activate")
+    with action:
+        result = action.popen([cmd], env=env, redirect=False, returnout=True, shell=True)
+    env_var_map = json.loads(result)
+    return env_var_map
+
+
+def split_conda_deps(deps):
+    conda_deps = []
+    pip_deps = []
+    for dep in deps:
+        dep_str = str(dep)
+        if dep_str.startswith(("-r", "-e", "-c", ":")):
+            pip_deps.append(dep)
+        elif dep_str.startswith("--pip"):
+            dep.name = dep_str[5:].strip()
+            pip_deps.append(dep)
+        else:
+            conda_deps.append(dep)
+    return conda_deps, pip_deps
+
+


### PR DESCRIPTION
Hi all,

I created a different initial conda support branch, trying to keep things simple where I can. 

My approach tries to follow all tox' hooks a bit more closely and converts the dependencies to a conda environment.yaml which can be installed in a single go (instead of having to switch envs and doing pips manually). 

It's not bug free yet, as tox is still picking up some wrong environment variables. kalefranz's ``get_activated_env_vars`` seems related, but the ``cmdbuilder`` commands are rather unwieldy..

The main issue this currently has, is that tox expects the python executable to be in ``./.tox/testenv/Scripts`` while conda puts that in the parent directory (``testenv``) and that's hard wired in the config (there's an assert in place preventing you from changing that). I tried making a symlink from within Python, but it complains about execution rights to do so.

Please take a look to see if it's of any use :)