### PR TITLE
Make conda environment optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,10 @@ eating it, too!
 By default, ``tox`` creates isolated environments using `virtualenv
 <https://virtualenv.pypa.io>`_ and installs dependencies from ``pip``.
 
-In contrast, when using the ``tox-conda`` plugin ``tox`` will use ``conda`` to create
-environments, and will install specified dependencies from ``conda``. This is
-useful for developers who rely on ``conda`` for environment management and
-package distribution but want to take advantage of the features provided by
+With the ``tox-conda`` plugin, ``tox`` can be configured to use ``conda`` to
+create environments, and will install specified dependencies from ``conda``.
+This is useful for developers who rely on ``conda`` for environment management
+and package distribution but want to take advantage of the features provided by
 ``tox`` for test automation.
 
 Installation
@@ -73,11 +73,10 @@ Usage
 Details on ``tox`` usage can be found in the `tox documentation
 <https://tox.readthedocs.io>`_.
 
-With the plugin installed and no other changes, the ``tox-conda`` plugin will use
-``conda`` to create environments and use ``pip`` to install dependencies that are
-given in the ``tox.ini`` configuration file.
+With the plugin installed, ``tox-conda`` plugin enables using ``conda`` to create
+environments and/or to install dependencies.
 
-``tox-conda`` adds two additional (and optional) settings to the ``[testenv]``
+``tox-conda`` adds three additional (and optional) settings to the ``[testenv]``
 section of configuration files:
 
 * ``conda_deps``, which is used to configure which dependencies are installed
@@ -88,6 +87,11 @@ section of configuration files:
 * ``conda_channels``, which specifies which channel(s) should be used for
   resolving ``conda`` dependencies. If not given, only the ``default`` channel will
   be used.
+
+* ``conda_env``, which can be used to explicitly create environments using ``conda``,
+  even if ``conda_deps`` is missing. If ``conda_deps`` is present, it takes precedence
+  over ``conda_env`` and ``conda`` will be used for environment creation. Defaults to
+  ``False``.
 
 An example configuration file is given below:
 

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -6,6 +6,7 @@ def test_conda(cmd, initproj):
                 [tox]
                 skipsdist=True
                 [testenv]
+                conda_env=True
                 commands = python -c 'import sys, os; \
                     print(os.path.exists(os.path.join(sys.prefix, "conda-meta")))'
             """

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -9,6 +9,7 @@ def test_conda_create(newconfig, mocksession):
         [],
         """
         [testenv:py123]
+        conda_env=True
     """,
     )
 
@@ -46,6 +47,7 @@ def test_install_deps_no_conda(newconfig, mocksession):
         [],
         """
         [testenv:py123]
+        conda_env=True
         deps=
             numpy
             astropy
@@ -69,6 +71,7 @@ def test_install_conda_deps(newconfig, mocksession):
         [],
         """
         [testenv:py123]
+        conda_env=True
         deps=
             numpy
             astropy
@@ -105,6 +108,7 @@ def test_install_conda_no_pip(newconfig, mocksession):
         [],
         """
         [testenv:py123]
+        conda_env=True
         conda_deps=
             pytest
             asdf
@@ -133,6 +137,7 @@ def test_update(tmpdir, newconfig, mocksession):
         [],
         """
         [testenv:py123]
+        conda_env=True
         deps=
             numpy
             astropy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,46 @@ def test_conda_force_deps(tmpdir, newconfig):
     assert hasattr(config.envconfigs["py1"], "conda_deps")
     assert len(config.envconfigs["py1"].conda_deps) == 2
     assert "something<42.1" == config.envconfigs["py1"].conda_deps[0].name
+
+
+def test_conda_env(tmpdir, newconfig):
+    config = newconfig(
+        [],
+        """
+        [tox]
+        toxworkdir = {}
+        [testenv:py1]
+        conda_env=True
+        deps=
+            hello
+    """.format(
+            tmpdir
+        ),
+    )
+
+    assert len(config.envconfigs) == 1
+    assert hasattr(config.envconfigs["py1"], "deps")
+    assert hasattr(config.envconfigs["py1"], "conda_deps")
+    assert hasattr(config.envconfigs["py1"], "conda_env")
+    assert config.envconfigs["py1"].conda_env
+
+
+def test_no_conda_env(tmpdir, newconfig):
+    config = newconfig(
+        [],
+        """
+        [tox]
+        toxworkdir = {}
+        [testenv:py1]
+        deps=
+            hello
+    """.format(
+            tmpdir
+        ),
+    )
+
+    assert len(config.envconfigs) == 1
+    assert hasattr(config.envconfigs["py1"], "deps")
+    assert hasattr(config.envconfigs["py1"], "conda_deps")
+    assert hasattr(config.envconfigs["py1"], "conda_env")
+    assert not config.envconfigs["py1"].conda_env

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -50,7 +50,7 @@ def tox_addoption(parser):
     )
 
     parser.add_testenv_attribute(
-        name="conda_env", type="bool", help="always use a conda environment", default=True
+        name="conda_env", type="bool", help="always use a conda environment", default=False
     )
 
 

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -49,6 +49,10 @@ def tox_addoption(parser):
         name="conda_channels", type="line-list", help="each line specifies a conda channel"
     )
 
+    parser.add_testenv_attribute(
+        name="conda_env", type="bool", help="always use a conda environment", default=True
+    )
+
 
 @hookimpl
 def tox_configure(config):
@@ -97,6 +101,10 @@ def tox_testenv_create(venv, action):
 
     tox.venv.cleanup_for_venv(venv)
     basepath = venv.path.dirpath()
+
+    # Don't use conda if it is not specified.
+    if not venv.envconfig.conda_deps and not venv.envconfig.conda_env:
+        return None
 
     # Check for venv.envconfig.sitepackages and venv.config.alwayscopy here
 

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -50,7 +50,7 @@ def tox_addoption(parser):
     )
 
     parser.add_testenv_attribute(
-        name="conda_env", type="bool", help="always use a conda environment", default=False
+        name="conda_env", type="bool", help="use conda to create test envs", default=False
     )
 
 


### PR DESCRIPTION
Turns off using conda to create environments by default, see #14.

This change will make it so conda is only used to create an environment if conda dependencies are specified or if conda is explicitly asked for via a `conda_env` flag, as suggested in the linked issue. To preserve existing behavior, `conda_deps` takes precedence over `conda_env` so that if the former is given, the latter is ignored (as opposed to throwing an error if `conda_env=False`).