### PR TITLE
Don't "display" progress bar during `conda install`

### DIFF
--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -89,11 +89,11 @@ def test_install_conda_deps(newconfig, mocksession):
     call = pcalls[-2]
     conda_cmd = call.args
     assert "conda" in os.path.split(conda_cmd[0])[-1]
-    assert conda_cmd[1:5] == ["install", "--yes", "-p", venv.path]
+    assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
     # Make sure that python is explicitly given as part of every conda install
     # in order to avoid inadvertant upgrades of python itself.
-    assert conda_cmd[5].startswith("python=")
-    assert conda_cmd[6:8] == ["pytest", "asdf"]
+    assert conda_cmd[6].startswith("python=")
+    assert conda_cmd[7:9] == ["pytest", "asdf"]
 
     pip_cmd = pcalls[-1].args
     assert pip_cmd[1:4] == ["-m", "pip", "install"]
@@ -124,7 +124,7 @@ def test_install_conda_no_pip(newconfig, mocksession):
     call = pcalls[-1]
     conda_cmd = call.args
     assert "conda" in os.path.split(conda_cmd[0])[-1]
-    assert conda_cmd[1:5] == ["install", "--yes", "-p", venv.path]
+    assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
 
 
 def test_update(tmpdir, newconfig, mocksession):

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -122,6 +122,7 @@ def install_conda_deps(venv, action, basepath, envdir):
 
     action.setactivity("installcondadeps", ", ".join(conda_deps))
 
+    # Install quietly to make the log cleaner
     args = [conda_exe, "install", "--quiet", "--yes", "-p", envdir]
     for channel in venv.envconfig.conda_channels:
         args += ["--channel", channel]

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -122,7 +122,7 @@ def install_conda_deps(venv, action, basepath, envdir):
 
     action.setactivity("installcondadeps", ", ".join(conda_deps))
 
-    args = [conda_exe, "install", "--yes", "-p", envdir]
+    args = [conda_exe, "install", "--quiet", "--yes", "-p", envdir]
     for channel in venv.envconfig.conda_channels:
         args += ["--channel", channel]
     # We include the python version in the conda requirements in order to make


### PR DESCRIPTION
This PR removes the unnecessary progress report from the log by suppressing the progress bar of the conda install command. This closes #43.

---

This is a backwards incompatible change if the `--quiet` command line option of `conda install` is not available for some conda versions.

I couldn't find the relevant entry in the [conda release notes](https://conda.io/projects/continuumio-conda/en/latest/release-notes.html), and I don't know what conda versions tox-conda supports. However, I found official-looking installers at [repo.anaconda.com/miniconda](https://repo.anaconda.com/miniconda/), and verified that version 1.6.0 (which is fairly old) already has the `--quiet` option.