### PR TITLE
Add support of conda-spec.txt and conda-env.yml files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ With the plugin enabled and no other changes, the ``tox-conda`` plugin will use
 ``conda`` to create environments and use ``pip`` to install dependencies that are
 given in the ``tox.ini`` configuration file.
 
-``tox-conda`` adds two additional (and optional) settings to the ``[testenv]``
+``tox-conda`` adds four additional (and optional) settings to the ``[testenv]``
 section of configuration files:
 
 * ``conda_deps``, which is used to configure which dependencies are installed
@@ -110,6 +110,21 @@ section of configuration files:
 * ``conda_channels``, which specifies which channel(s) should be used for
   resolving ``conda`` dependencies. If not given, only the ``default`` channel will
   be used.
+
+* ``conda_spec``, which specifies a ``conda-spec.txt`` file that lists conda
+  dependencies to install and will be combined with ``conda_deps`` (if given). These
+  dependencies can be in a general from (e.g., ``numpy>=1.17.5``) or an explicit
+  form (eg., https://conda.anaconda.org/conda-forge/linux-64/numpy-1.17.5-py38h95a1406_0.tar.bz2),
+  *however*, if the ``@EXPLICIT`` header is in ``conda-spec.txt``, *all* general
+  dependencies will be ignored, including those given in ``conda_deps``.
+
+* ``conda_env``, which specifies a ``conda-env.yml`` file to create a base conda
+  environment for the test. The ``conda-env.yml`` file is self-contained and
+  if the desired python version and conda channels to use is not given, the latest
+  python version and default channels will be used. The above ``conda_deps``,
+  ``conda_channels``, and ``conda_spec`` arguments, if used in conjunction with
+  a ``conda-env.yml`` file, will be used to *update* the environment *after* the
+  initial environment creation.
 
 An example configuration file is given below:
 

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ section of configuration files:
 * ``conda_env``, which specifies a ``conda-env.yml`` file to create a base conda
   environment for the test. The ``conda-env.yml`` file is self-contained and
   if the desired python version and conda channels to use is not given, the latest
-  python version and default channels will be used. The above ``conda_deps``,
+  python version (if needed) and default channels will be used. The above ``conda_deps``,
   ``conda_channels``, and ``conda_spec`` arguments, if used in conjunction with
   a ``conda-env.yml`` file, will be used to *update* the environment *after* the
   initial environment creation.

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -187,7 +187,7 @@ def test_conda_spec(tmpdir, newconfig, mocksession):
     assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
     # Make sure that python is explicitly given as part of every conda install
     # in order to avoid inadvertent upgrades of python itself.
-    assert conda_cmd[5].startswith("python=")
+    assert conda_cmd[6].startswith("python=")
     assert conda_cmd[7:9] == ["numpy", "astropy"]
     assert conda_cmd[-1].startswith("--file")
     assert conda_cmd[-1].endswith("conda-spec.txt")

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -151,3 +151,145 @@ def test_update(tmpdir, newconfig, mocksession):
     with mocksession.newaction(venv.name, "update") as action:
         venv.update(action)
         venv.installpkg(pkg, action)
+
+
+def test_conda_spec(tmpdir, newconfig, mocksession):
+    """Test environment creation when conda_spec given"""
+    txt = tmpdir.join("conda-spec.txt")
+    txt.write(
+        """
+        pytest
+        """
+    )
+    config = newconfig(
+        [],
+        """
+        [testenv:py123]
+        conda_deps=
+            numpy
+            astropy
+        conda_spec={}
+        """.format(str(txt)),
+    )
+    venv, action, pcalls = create_test_env(config, mocksession, "py123")
+
+    assert venv.envconfig.conda_spec
+    assert len(venv.envconfig.conda_deps) == 2
+
+    tox_testenv_install_deps(action=action, venv=venv)
+    # We expect conda_spec to be appended to conda deps install
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
+    conda_cmd = call.args
+    assert "conda" in os.path.split(conda_cmd[0])[-1]
+    assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
+    # Make sure that python is explicitly given as part of every conda install
+    # in order to avoid inadvertent upgrades of python itself.
+    assert conda_cmd[5].startswith("python=")
+    assert conda_cmd[7:9] == ["numpy", "astropy"]
+    assert conda_cmd[-1].startswith("--file")
+    assert conda_cmd[-1].endswith("conda-spec.txt")
+
+
+def test_conda_env(tmpdir, newconfig, mocksession):
+    """Test environment creation when conda_env given"""
+    yml = tmpdir.join("conda-env.yml")
+    yml.write(
+        """
+        name: tox-conda
+        channels:
+          - conda-forge
+          - nodefaults
+        dependencies:
+          - numpy
+          - astropy
+          - pip:
+            - pytest
+        """
+    )
+    config = newconfig(
+        [],
+        """
+        [testenv:py123]
+        conda_env={}
+        """.format(str(yml)),
+    )
+
+    venv = VirtualEnv(config.envconfigs["py123"])
+    assert venv.path == config.envconfigs["py123"].envdir
+
+    venv, action, pcalls = create_test_env(config, mocksession, "py123")
+    assert venv.envconfig.conda_env
+
+    with mocksession.newaction(venv.name, "getenv") as action:
+        tox_testenv_create(action=action, venv=venv)
+    pcalls = mocksession._pcalls
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
+    cmd = call.args
+    assert "conda" in os.path.split(cmd[0])[-1]
+    assert cmd[1:4] == ["env", "create", "-p"]
+    assert venv.path == call.args[4]
+    assert call.args[5].startswith("--file")
+    assert call.args[6].endswith("conda-env.yml")
+
+
+def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
+    """Test environment creation when conda_env and conda_spec are given"""
+    yml = tmpdir.join("conda-env.yml")
+    yml.write(
+        """
+        name: tox-conda
+        channels:
+          - conda-forge
+          - nodefaults
+        dependencies:
+          - numpy
+          - astropy
+        """
+    )
+    txt = tmpdir.join("conda-spec.txt")
+    txt.write(
+        """
+        pytest
+        """
+    )
+    config = newconfig(
+        [],
+        """
+        [testenv:py123]
+        conda_env={}
+        conda_spec={}
+        """.format(str(yml), str(txt)),
+    )
+    venv, action, pcalls = create_test_env(config, mocksession, "py123")
+
+    assert venv.envconfig.conda_env
+    assert venv.envconfig.conda_spec
+
+    with mocksession.newaction(venv.name, "getenv") as action:
+        tox_testenv_create(action=action, venv=venv)
+    pcalls = mocksession._pcalls
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
+    cmd = call.args
+    assert "conda" in os.path.split(cmd[0])[-1]
+    assert cmd[1:4] == ["env", "create", "-p"]
+    assert venv.path == call.args[4]
+    assert call.args[5].startswith("--file")
+    assert call.args[6].endswith("conda-env.yml")
+
+    with mocksession.newaction(venv.name, "getenv") as action:
+        tox_testenv_install_deps(action=action, venv=venv)
+    pcalls = mocksession._pcalls
+    # We expect conda_spec to be appended to conda deps install
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
+    conda_cmd = call.args
+    assert "conda" in os.path.split(conda_cmd[0])[-1]
+    assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
+    # Make sure that python is explicitly given as part of every conda install
+    # in order to avoid inadvertent upgrades of python itself.
+    assert conda_cmd[6].startswith("python=")
+    assert conda_cmd[-1].startswith("--file")
+    assert conda_cmd[-1].endswith("conda-spec.txt")

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -169,7 +169,9 @@ def test_conda_spec(tmpdir, newconfig, mocksession):
             numpy
             astropy
         conda_spec={}
-        """.format(str(txt)),
+        """.format(
+            str(txt)
+        ),
     )
     venv, action, pcalls = create_test_env(config, mocksession, "py123")
 
@@ -212,7 +214,9 @@ def test_conda_env(tmpdir, newconfig, mocksession):
         """
         [testenv:py123]
         conda_env={}
-        """.format(str(yml)),
+        """.format(
+            str(yml)
+        ),
     )
 
     venv = VirtualEnv(config.envconfigs["py123"])
@@ -260,7 +264,9 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
         [testenv:py123]
         conda_env={}
         conda_spec={}
-        """.format(str(yml), str(txt)),
+        """.format(
+            str(yml), str(txt)
+        ),
     )
     venv, action, pcalls = create_test_env(config, mocksession, "py123")
 

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -135,6 +135,10 @@ def install_conda_deps(venv, action, basepath, envdir):
     conda_exe = venv.envconfig.conda_exe
     # Account for the fact that we have a list of DepOptions
     conda_deps = [str(dep.name) for dep in venv.envconfig.conda_deps]
+    # Add the conda-spec.txt file to the end of the conda deps b/c any deps
+    # after --file option(s) are ignored
+    if venv.envconfig.conda_spec:
+        conda_deps.append("--file={}".format(venv.envconfig.conda_spec))
 
     action.setactivity("installcondadeps", ", ".join(conda_deps))
 
@@ -159,6 +163,9 @@ def tox_testenv_install_deps(venv, action):
     saved_deps = copy.deepcopy(venv.envconfig.deps)
 
     num_conda_deps = len(venv.envconfig.conda_deps)
+    if venv.envconfig.conda_spec:
+        num_conda_deps += 1
+
     if num_conda_deps > 0:
         install_conda_deps(venv, action, basepath, envdir)
         # Account for the fact that we added the conda_deps to the deps list in

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -42,10 +42,10 @@ def get_py_version(envconfig, action):
 
 @hookimpl
 def tox_addoption(parser):
-    parser. add_testenv_attribute(
+    parser.add_testenv_attribute(
         name="conda_env", type="path", help="specify a conda environment.yml file"
     )
-    parser. add_testenv_attribute(
+    parser.add_testenv_attribute(
         name="conda_spec", type="path", help="specify a conda spec-file.txt file"
     )
 
@@ -64,7 +64,7 @@ def tox_configure(config):
     for _, envconfig in config.envconfigs.items():
         # Make sure the right environment is activated. This works because we're
         # creating environments using the `-p/--prefix` option in `tox_testenv_create`
-        envconfig.setenv['CONDA_DEFAULT_ENV'] = envconfig.setenv['TOX_ENV_DIR']
+        envconfig.setenv["CONDA_DEFAULT_ENV"] = envconfig.setenv["TOX_ENV_DIR"]
 
         conda_deps = [DepConfig(str(name)) for name in envconfig.conda_deps]
         # Add the conda-spec.txt file to the end of the conda deps b/c any deps

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -62,6 +62,10 @@ def tox_configure(config):
     # the conda dependencies when it decides whether an existing environment
     # needs to be updated before being used
     for _, envconfig in config.envconfigs.items():
+        # Make sure the right environment is activated. This works because we're
+        # creating environments using the `-p/--prefix` option in `tox_testenv_create`
+        envconfig.setenv['CONDA_DEFAULT_ENV'] = envconfig.setenv['TOX_ENV_DIR']
+
         conda_deps = [DepConfig(str(name)) for name in envconfig.conda_deps]
         # Add the conda-spec.txt file to the end of the conda deps b/c any deps
         # after --file option(s) are ignored
@@ -97,7 +101,6 @@ def tox_testenv_create(venv, action):
     basepath = venv.path.dirpath()
 
     # Check for venv.envconfig.sitepackages and venv.config.alwayscopy here
-
     conda_exe = find_conda(action)
     venv.envconfig.conda_exe = conda_exe
 


### PR DESCRIPTION
# Proposed changes

The PR adds two additional (and optional) settings to the ``[testenv]`` section of tox configuration files:

```
[testenv]
conda_spec=conda-spec.txt
conda_env=conda-env.txt
```

which can be used in conjunction with this plugins current additional (and optional) settings `conda_deps` and `conda_channels`. 

## conda-spec.txt

Currently, this plugin uses `conda_deps` by appending them to a command like:

```
conda install --yes --prefix $TOX_ENV_DIR [conda_python] [conda_deps]
```

The `conda_spec` config option specifies a (single) `conda-spec.txt` file (as a [path](https://tox.readthedocs.io/en/2.4.1/plugins.html#tox.config.Parser.add_testenv_attribute) type), which will (and must) be appended to the above command like

```
conda install --yes --prefix $TOX_ENV_DIR [--channels conda_channels] [conda_python] [conda_deps] --file=[conda_spec]
```
and the dependencies listed inside `conda_spec.txt` will be combined with the dependencies listed in `conda_deps`, using the channels specified in `conda_channels`.  

Conda allows multiple `--file` commands to be given, but because the conda commands are executed from within the `.tox` directory, the specified file would need to be transformed from relative to the repository root to absolute. Using the  [path](https://tox.readthedocs.io/en/2.4.1/plugins.html#tox.config.Parser.add_testenv_attribute) type does that but only allows a single file. A `line-list` type could be used but that relative-to-absolute transformation would need to be handled here, and I don't personally see much need beyond a single `spec-file.txt` per (tox)  test environment. 

Another conda-weirdness to know about when evaluating this proposal, is that both general dependencies (e.g., `numpy>=1.17.5`) and explicit dependencies (e.g., https://conda.anaconda.org/conda-forge/linux-64/numpy-1.17.5-py38h95a1406_0.tar.bz2) are allowed inside the `conda-spec.txt` file, but explicit dependencies *are not* allowed to be mixed with general ones on the command line (ergo, not allowed in `conda_deps`). However, if the ``@EXPLICIT`` header is in ``conda-spec.txt``, *all* general dependencies will be ignored, including those given in ``conda_deps``. Notably
* `conda list --export > conda-spec.txt` will produce general dependencies
* `conda list --explicit > conda-spec.txt` will produce explicit dependencies with the `@EXPLICIT` header


## conda-env.yml

currently, this plugin creates an initial and mostly empty conda environment with a command like:

```
conda install --yes --prefix $TOX_ENV_DIR [--channels conda_channels] [conda_python]
```
The `conda_env` config option specifies a (single) `conda-env.yml` file (as a [path](https://tox.readthedocs.io/en/2.4.1/plugins.html#tox.config.Parser.add_testenv_attribute) type), which is **instead** used to create an initial environment like:

```
conda env create --prefix $TOX_ENV_DIR --file [conda_env] 
```

Importantly:
* using `--prefix` on the command line as above will override any `name:` or `prefix:` specification inside the `conda-env.yml` file
* this file is self-contained
  * conda channels needs to be specified inside this file otherwise the conda defaults will be used
  * python (and version) needs to be specified inside this file otherwise the latest python version will be used *if it's needed* (this can create python-less initial environments, but python will be installed when the environment is updated) 
  * the `conda_deps`, `conda_channels` and `conda_spec` options are only used *later* to *update* this initial environment

### Other possible solutions

Instead of using `conda env create` and the `conda-env.yml` file directly, we could parse `conda-env.yml` and prepend the channels and dependencies to `conda_channels` and `conda_deps` respectively, but this would add a PyYAML (or similar) dependency and *may* not be what the user is expecting. Because `conda-spec.txt` can be used that way, I think explicitly using `conda env create ... --file conda-env.yml` is a better option.

---
## Also: environment activation

When testing these changes to this plugin, I encountered tox-conda always using my base conda environment to run the tests and not activating the created environment. This seems to be the root issue for both #24 and #29. You can confirm this is happening with a pytest test like:

```python
import subprocess

def test_tox_conda_env():
    print(subprocess.check_output('conda list', shell=True, universal_newlines=True))
```

and setting this in your `tox.ini`

```
[testenv] 
commands = pytest -s {posargs}
```

Because we're always creating environment based on a `--prefix`, simply adding an environment variable to the tox test environment like:

```python
envconfig.setenv['CONDA_DEFAULT_ENV'] = envconfig.setenv['TOX_ENV_DIR']
```
will cause the correct conda environment to be activated in that test environment.

Importantly, tox-conda's current tests only mock the commands to conda and so do not actually create any conda environments, nor determine if the environments are activated/created correctly, so this was missed. 

---

Fixes #13 
Also fixes #24 and fixes #29 