### PR TITLE
Fixes for windows

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -18,8 +18,8 @@ def test_conda(cmd, initproj):
         return next((i for i, l in enumerate(result.outlines) if l.startswith(m)), None)
 
     assert any(
-        "create --yes -p " in l
-        for l in result.outlines[index_of("py create: ") + 1 : index_of("py installed: ")]
+        "create --yes -p " in line
+        for line in result.outlines[index_of("py create: ") + 1 : index_of("py installed: ")]
     ), result.output()
 
     assert result.outlines[-4] == "True"

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,11 @@ passenv = HOMEPATH
           # `error setting certificate verify locations` error
           PROGRAMDATA
 extras = lint
-deps = pre-commit >= 1.14.4, < 2
+deps =
+    # pre-commit depends on virtualenv which is broken with anaconda on windows for versions 20.0.34+
+    # see https://github.com/pypa/virtualenv/issues/1986
+    virtualenv < 20.0.34
+    pre-commit >= 1.14.4, < 2
 skip_install = True
 commands = pre-commit run --all-files --show-diff-on-failure
            python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 [tox]
 envlist =
     fix_lint
-    py27
     py34
     py35
     py36

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -100,6 +100,12 @@ def tox_testenv_create(venv, action):
 
     venv.envconfig.conda_python = python
 
+    # let the venv know about the target interpreter just installed in our conda env, otherwise
+    # we'll have a mismatch later because tox expects the interpreter to be existing outside of
+    # the env
+    del venv.envconfig.config.interpreters.name2executable[venv.name]
+    venv.envconfig.config.interpreters.get_executable(venv.envconfig)
+
     return True
 
 


### PR DESCRIPTION
Fixes for #51.

Also includes fixes for:

- flake8 violations raised by `tox -e fix_lint`
- a bug on windows for virtualenv 20.0.34+
- py27 not declared as supported by tox-conda