### PR TITLE
Add conda_install_args setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,11 @@ section of configuration files:
   a ``conda-env.yml`` file, will be used to *update* the environment *after* the
   initial environment creation.
 
+* ``conda_install_args``, which is used to pass arguments to the command ``conda install``.
+  The passed arguments are inserted in the command line before the dependencies.
+  For instance, passing ``--override-channels`` will create more reproducible environments
+  because the channels defined in the users ``.condarc`` will not interfer.
+
 An example configuration file is given below:
 
 ::
@@ -144,6 +149,8 @@ An example configuration file is given below:
        stable: numpy=1.15
    conda_channels=
        conda-forge
+   conda_install_args=
+       --override-channels
    commands=
        pytest {posargs}
 

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -299,3 +299,25 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     assert conda_cmd[6].startswith("python=")
     assert conda_cmd[-1].startswith("--file")
     assert conda_cmd[-1].endswith("conda-spec.txt")
+
+
+def test_conda_install_args(newconfig, mocksession):
+    config = newconfig(
+        [],
+        """
+        [testenv:py123]
+        conda_deps=
+            numpy
+        conda_install_args=
+            --override-channels
+    """,
+    )
+
+    venv, action, pcalls = create_test_env(config, mocksession, "py123")
+
+    assert len(venv.envconfig.conda_install_args) == 1
+
+    tox_testenv_install_deps(action=action, venv=venv)
+
+    call = pcalls[-1]
+    assert call.args[6] == "--override-channels"

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -57,6 +57,12 @@ def tox_addoption(parser):
         name="conda_channels", type="line-list", help="each line specifies a conda channel"
     )
 
+    parser.add_testenv_attribute(
+        name="conda_install_args",
+        type="line-list",
+        help="each line specifies a conda install argument",
+    )
+
 
 @hookimpl
 def tox_configure(config):
@@ -148,6 +154,10 @@ def install_conda_deps(venv, action, basepath, envdir):
     args = [conda_exe, "install", "--quiet", "--yes", "-p", envdir]
     for channel in venv.envconfig.conda_channels:
         args += ["--channel", channel]
+
+    # Add end-user conda install args
+    args += venv.envconfig.conda_install_args
+
     # We include the python version in the conda requirements in order to make
     # sure that none of the other conda requirements inadvertently downgrade
     # python in this environment. If any of the requirements are in conflict


### PR DESCRIPTION
Depending on the contents of a user's `.condarc`, the environments created with tox-conda may not be reproducible.
Tests results may differ for some users because some of the dependencies are pulled from different repositories.

This PR add the setting `conda_install_args` to pass arguments to the conda install command line used by tox.
This allows in particular to pass `--override-channels` to overcome the aforementioned non-reproducibility.