### PR TITLE
Add conda_create_args setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,11 @@ section of configuration files:
   a ``conda-env.yml`` file, will be used to *update* the environment *after* the
   initial environment creation.
 
+* ``conda_create_args``, which is used to pass arguments to the command ``conda create``.
+  The passed arguments are inserted in the command line before the python package.
+  For instance, passing ``--override-channels`` will create more reproducible environments
+  because the channels defined in the users ``.condarc`` will not interfer.
+
 * ``conda_install_args``, which is used to pass arguments to the command ``conda install``.
   The passed arguments are inserted in the command line before the dependencies.
   For instance, passing ``--override-channels`` will create more reproducible environments

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -321,3 +321,30 @@ def test_conda_install_args(newconfig, mocksession):
 
     call = pcalls[-1]
     assert call.args[6] == "--override-channels"
+
+
+def test_conda_create_args(newconfig, mocksession):
+    config = newconfig(
+        [],
+        """
+        [testenv:py123]
+        conda_create_args=
+            --override-channels
+    """,
+    )
+
+    venv = VirtualEnv(config.envconfigs["py123"])
+    assert venv.path == config.envconfigs["py123"].envdir
+
+    with mocksession.newaction(venv.name, "getenv") as action:
+        tox_testenv_create(action=action, venv=venv)
+    pcalls = mocksession._pcalls
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
+    assert "conda" in call.args[0]
+    assert "create" == call.args[1]
+    assert "--yes" == call.args[2]
+    assert "-p" == call.args[3]
+    assert venv.path == call.args[4]
+    assert call.args[5] == "--override-channels"
+    assert call.args[6].startswith("python=")

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -63,6 +63,12 @@ def tox_addoption(parser):
         help="each line specifies a conda install argument",
     )
 
+    parser.add_testenv_attribute(
+        name="conda_create_args",
+        type="line-list",
+        help="each line specifies a conda create argument",
+    )
+
 
 @hookimpl
 def tox_configure(config):
@@ -124,6 +130,10 @@ def tox_testenv_create(venv, action):
         args = [conda_exe, "create", "--yes", "-p", envdir]
         for channel in venv.envconfig.conda_channels:
             args += ["--channel", channel]
+
+        # Add end-user conda create args
+        args += venv.envconfig.conda_create_args
+
         args += [python]
 
     venv._pcall(args, venv=False, action=action, cwd=basepath)


### PR DESCRIPTION
Like `conda_install_args`, but for the `conda create` command to allow finer control.
This is also important for environment reproducibility.