### PR TITLE
Install pypi dependencies and run all commands from activated anaconda envs

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -23,3 +23,34 @@ def test_conda(cmd, initproj):
     ), result.output()
 
     assert result.outlines[-4] == "True"
+
+
+def test_conda_run_command(cmd, initproj):
+    """Check that all the commands are run from an activated anaconda env.
+
+    This is done by looking at the CONDA_PREFIX environment variable which contains
+    the environment name.
+    This variable is dumped to a file because commands_{pre,post} do not redirect
+    their outputs.
+    """
+    env_name = "foobar"
+    initproj(
+        "pkg-1",
+        filedefs={
+            "tox.ini": """
+                [tox]
+                skipsdist=True
+                [testenv:{}]
+                commands_pre = python -c "import os; open('commands_pre', 'w').write(os.environ['CONDA_PREFIX'])"
+                commands = python -c "import os; open('commands', 'w').write(os.environ['CONDA_PREFIX'])"
+                commands_post = python -c "import os; open('commands_post', 'w').write(os.environ['CONDA_PREFIX'])"
+            """.format(  # noqa: E501
+                env_name
+            )
+        },
+    )
+    result = cmd("-v", "-e", env_name)
+    result.assert_success()
+
+    for filename in ("commands_pre", "commands_post", "commands"):
+        assert open(filename).read().endswith(env_name)

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -62,7 +62,7 @@ def test_install_deps_no_conda(newconfig, mocksession):
     assert len(pcalls) >= 1
     call = pcalls[-1]
     cmd = call.args
-    assert cmd[1:4] == ["-m", "pip", "install"]
+    assert cmd[6:9] == ["-m", "pip", "install"]
 
 
 def test_install_conda_deps(newconfig, mocksession):
@@ -97,8 +97,8 @@ def test_install_conda_deps(newconfig, mocksession):
     assert conda_cmd[7:9] == ["pytest", "asdf"]
 
     pip_cmd = pcalls[-1].args
-    assert pip_cmd[1:4] == ["-m", "pip", "install"]
-    assert pip_cmd[4:6] == ["numpy", "astropy"]
+    assert pip_cmd[6:9] == ["-m", "pip", "install"]
+    assert pip_cmd[9:11] == ["numpy", "astropy"]
 
 
 def test_install_conda_no_pip(newconfig, mocksession):


### PR DESCRIPTION
Currently, tox-conda does not activate an anaconda environment, this has some drawbacks:

- some anaconda packages set environment variables that are only accessible in an activated environment,
- the PATH environment variable lacks some search paths on Windows (#24),
- Numpy have troubles on Windows (#37).

This PR fixes these issues not by activating an anaconda environment but by using the `conda run` command which can run an arbitrary command from a temporarily activated environment. 

With this PR, I no longer have to add the following workaround on Windows:
```
setenv =
    CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
    PATH = {envdir}{:}{envdir}\Library\mingw-w64\bin{:}{envdir}\Library\usr\bin{:}{envdir}\Library\bin{:}{envdir}\Scripts{:}{envdir}\bin{:}{env:PATH}

```