### PR TITLE
Fix req file in deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,10 @@ section of configuration files:
   For instance, passing ``--override-channels`` will create more reproducible environments
   because the channels defined in the users ``.condarc`` will not interfer.
 
+* If `mamba <https://mamba.readthedocs.io>`_ is installed in the same environment as tox,
+  you may use it instead of the ``conda`` executable by setting the environment variable
+  ``CONDA_EXE=mamba`` in the shell where ``tox`` is called.
+
 An example configuration file is given below:
 
 ::

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -41,13 +41,16 @@ def test_conda_run_command(cmd, initproj):
                 [tox]
                 skipsdist=True
                 [testenv:{}]
-                deps = pip>0,<999
+                deps =
+                    pip>0,<999
+                    -r requirements.txt
                 commands_pre = python -c "import os; open('commands_pre', 'w').write(os.environ['CONDA_PREFIX'])"
                 commands = python -c "import os; open('commands', 'w').write(os.environ['CONDA_PREFIX'])"
                 commands_post = python -c "import os; open('commands_post', 'w').write(os.environ['CONDA_PREFIX'])"
             """.format(  # noqa: E501
                 env_name
-            )
+            ),
+            "requirements.txt": "",
         },
     )
 


### PR DESCRIPTION
When the deps section contains requirements files, the deps installation step crashes because the requirement files are searched by pip relatively to the parent directory of the parent temporary requirement file.

Also add info about how to use mamba instead of conda.