### PR TITLE
Let the user know when the conda executable is not found

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -89,7 +89,7 @@ def test_missing_conda(cmd, initproj, monkeypatch):
     # Prevent conda from being found.
     original_which = shutil.which
 
-    def which(path):
+    def which(path):  # pragma: no cover
         if path.endswith("conda"):
             return None
         return original_which(path)

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -1,3 +1,8 @@
+import shutil
+
+import tox_conda.plugin
+
+
 def test_conda(cmd, initproj):
     initproj(
         "pkg-1",
@@ -66,3 +71,31 @@ def test_conda_run_command(cmd, initproj):
 
     for filename in ("commands_pre", "commands_post", "commands"):
         assert open(filename).read().endswith(env_name)
+
+
+def test_missing_conda(cmd, initproj, monkeypatch):
+    """Check that an error is shown when the conda executable is not found."""
+
+    initproj(
+        "pkg-1",
+        filedefs={
+            "tox.ini": """
+                [tox]
+                require = tox-conda
+            """,
+        },
+    )
+
+    # Prevent conda from being found.
+    original_which = shutil.which
+
+    def which(path):
+        if path.endswith("conda"):
+            return None
+        return original_which(path)
+
+    monkeypatch.setattr(shutil, "which", which)
+
+    result = cmd()
+
+    assert result.outlines == ["ERROR: {}".format(tox_conda.plugin.MISSING_CONDA_ERROR)]

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -14,6 +14,8 @@ from tox.venv import VirtualEnv
 
 hookimpl = pluggy.HookimplMarker("tox")
 
+MISSING_CONDA_ERROR = "Cannot locate the conda executable."
+
 
 class CondaDepOption(DepOption):
     name = "conda_deps"
@@ -160,12 +162,20 @@ def find_conda():
 
     path = shutil.which("conda")
 
+    if path is None:
+        _exit_on_missing_conda()
+
     try:
         subprocess.check_call([str(path), "-h"])
     except subprocess.CalledProcessError:
-        raise RuntimeError("Can't locate conda executable")
+        _exit_on_missing_conda()
 
     return path
+
+
+def _exit_on_missing_conda():
+    tox.reporter.error(MISSING_CONDA_ERROR)
+    raise SystemExit(0)
 
 
 @hookimpl


### PR DESCRIPTION
Instead of having a cryptic trace-back.