### PR TITLE
Remove conda run requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,7 @@ useful for developers who rely on ``conda`` for environment management and
 package distribution but want to take advantage of the features provided by
 ``tox`` for test automation.
 
-As of version 0.8, ``tox-conda`` relies on the ``conda run`` command
-with the option ``--no-capture-output`` which is
-available since ``conda`` version 4.9.0.
+``tox-conda`` has not been tested with ``conda`` version below 4.5.
 
 Getting Started
 ---------------

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -47,7 +47,7 @@ def test_conda_run_command(cmd, initproj):
                 skipsdist=True
                 [testenv:{}]
                 deps =
-                    pip>0,<999
+                    pip >0,<999
                     -r requirements.txt
                 commands_pre = python -c "import os; open('commands_pre', 'w').write(os.environ['CONDA_PREFIX'])"
                 commands = python -c "import os; open('commands', 'w').write(os.environ['CONDA_PREFIX'])"

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -90,13 +90,7 @@ def test_install_deps_no_conda(newconfig, mocksession, monkeypatch):
     assert re.match(pattern, script_lines[0])
 
     cmd = script_lines[1].split()
-    assert cmd[-5:-2] == ["-m", "pip", "install"]
-    assert cmd[-2] == "-rrequirements.txt"
-
-    # Get the deps from the requirements file.
-    with open(cmd[-1][2:]) as stream:
-        deps = [line.strip() for line in stream.readlines()]
-    assert deps == ["numpy", "astropy"]
+    assert cmd[-6:] == ["-m", "pip", "install", "numpy", "-rrequirements.txt", "astropy"]
 
 
 def test_install_conda_deps(newconfig, mocksession):

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -1,7 +1,10 @@
 import os
+import re
 
+import tox
 from tox.venv import VirtualEnv
 
+from tox_conda.env_activator import PopenInActivatedEnv
 from tox_conda.plugin import tox_testenv_create, tox_testenv_install_deps
 
 
@@ -41,22 +44,28 @@ def create_test_env(config, mocksession, envname):
     return venv, action, pcalls
 
 
-def test_install_deps_no_conda(newconfig, mocksession):
+def test_install_deps_no_conda(newconfig, mocksession, monkeypatch):
     """Test installation using conda when no conda_deps are given"""
+    # No longer remove the temporary script, so we can check its contents.
+    monkeypatch.delattr(PopenInActivatedEnv, "__del__", raising=False)
+
+    env_name = "py123"
     config = newconfig(
         [],
         """
-        [testenv:py123]
+        [testenv:{}]
         deps=
             numpy
             -r requirements.txt
             astropy
-    """,
+    """.format(
+            env_name
+        ),
     )
 
     config.toxinidir.join("requirements.txt").write("")
 
-    venv, action, pcalls = create_test_env(config, mocksession, "py123")
+    venv, action, pcalls = create_test_env(config, mocksession, env_name)
 
     assert len(venv.envconfig.deps) == 3
     assert len(venv.envconfig.conda_deps) == 0
@@ -64,13 +73,28 @@ def test_install_deps_no_conda(newconfig, mocksession):
     tox_testenv_install_deps(action=action, venv=venv)
 
     assert len(pcalls) >= 1
+
     call = pcalls[-1]
-    cmd = call.args
-    assert cmd[6:9] == ["-m", "pip", "install"]
-    assert cmd[9] == "-rrequirements.txt"
+
+    if tox.INFO.IS_WIN:
+        script_lines = " ".join(call.args).split(" && ", maxsplit=1)
+        pattern = r"conda\.bat activate .*{}".format(re.escape(env_name))
+    else:
+        # Get the cmd args from the script.
+        shell, cmd_script = call.args
+        assert shell == "/bin/sh"
+        with open(cmd_script) as stream:
+            script_lines = stream.readlines()
+        pattern = r"eval \$\(/.*/conda shell\.posix activate /.*/{}\)".format(env_name)
+
+    assert re.match(pattern, script_lines[0])
+
+    cmd = script_lines[1].split()
+    assert cmd[-5:-2] == ["-m", "pip", "install"]
+    assert cmd[-2] == "-rrequirements.txt"
 
     # Get the deps from the requirements file.
-    with open(cmd[10][2:]) as stream:
+    with open(cmd[-1][2:]) as stream:
         deps = [line.strip() for line in stream.readlines()]
     assert deps == ["numpy", "astropy"]
 
@@ -102,12 +126,9 @@ def test_install_conda_deps(newconfig, mocksession):
     assert "conda" in os.path.split(conda_cmd[0])[-1]
     assert conda_cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
     # Make sure that python is explicitly given as part of every conda install
-    # in order to avoid inadvertant upgrades of python itself.
+    # in order to avoid inadvertent upgrades of python itself.
     assert conda_cmd[6].startswith("python=")
     assert conda_cmd[7:9] == ["pytest", "asdf"]
-
-    pip_cmd = pcalls[-1].args
-    assert pip_cmd[6:9] == ["-m", "pip", "install"]
 
 
 def test_install_conda_no_pip(newconfig, mocksession):

--- a/tox_conda/env_activator.py
+++ b/tox_conda/env_activator.py
@@ -1,0 +1,127 @@
+"""Wrap the tox command for subprocess to activate the target anaconda env."""
+import abc
+import os
+import pipes
+import tempfile
+from contextlib import contextmanager
+
+import tox
+
+
+class PopenInActivatedEnvBase(abc.ABC):
+    """A functor that calls popen in an activated anaconda env."""
+
+    def __init__(self, venv, popen):
+        self._venv = venv
+        self.__popen = popen
+
+    def __call__(self, cmd_args, **kwargs):
+        wrapped_cmd_args = self._wrap_cmd_args(cmd_args)
+        return self.__popen(wrapped_cmd_args, **kwargs)
+
+    @abc.abstractmethod
+    def _wrap_cmd_args(self, cmd_args):
+        ...
+
+
+class PopenInActivatedEnvPosix(PopenInActivatedEnvBase):
+    """Call popen in an activated anaconda env on POSIX platforms.
+
+    The command to be executed are written to a temporary shell script.
+    The shell script first activates the env.
+    """
+
+    def __init__(self, venv, popen):
+        super().__init__(venv, popen)
+        self.__tmp_file = None
+
+    def _wrap_cmd_args(self, cmd_args):
+        conda_activate_cmd = "eval $({conda_exe} shell.posix activate {envdir})".format(
+            conda_exe=self._venv.envconfig.conda_exe, envdir=self._venv.envconfig.envdir
+        )
+
+        # Get a temporary file path.
+        with tempfile.NamedTemporaryFile() as fp:
+            self.__tmp_file = fp.name
+
+        cmd_args_shell = " ".join(map(pipes.quote, cmd_args))
+
+        with open(self.__tmp_file, "w") as fp:
+            fp.writelines((conda_activate_cmd, "\n", cmd_args_shell))
+
+        return ["/bin/sh", self.__tmp_file]
+
+    def __del__(self):
+        # Delete the eventual temporary script.
+        if self.__tmp_file is not None:
+            os.remove(self.__tmp_file)
+
+
+class PopenInActivatedEnvWindows(PopenInActivatedEnvBase):
+    """Call popen in an activated anaconda env on Windows.
+
+    The shell is temporary forced to cmd.exe and the env is activated accordingly.
+    """
+
+    def __call__(self, cmd_args, **kwargs):
+        # Backup COMSPEC before setting it to cmd.exe.
+        old_comspec = os.environ.get("COMSPEC")
+        self.__ensure_comspecs_is_cmd_exe()
+
+        output = super().__call__(cmd_args, **kwargs)
+
+        # Revert COMSPEC to its initial value.
+        if old_comspec is None:
+            del os.environ["COMSPEC"]
+        else:
+            os.environ["COMSPEC"] = old_comspec
+
+        return output
+
+    def _wrap_cmd_args(self, cmd_args):
+        conda_activate_cmd = "conda.bat activate {envdir}".format(
+            envdir=self._venv.envconfig.envdir
+        )
+        return conda_activate_cmd.split() + ["&&"] + cmd_args
+
+    def __ensure_comspecs_is_cmd_exe(self):
+        if os.path.basename(os.environ.get("COMSPEC", "")).lower() == "cmd.exe":
+            return
+
+        for env_var in ("SystemRoot", "windir"):
+            root_path = os.environ.get(env_var)
+            if root_path is None:
+                continue
+            cmd_exe = os.path.join(root_path, "System32", "cmd.exe")
+            if os.path.isfile(cmd_exe):
+                os.environ["COMSPEC"] = cmd_exe
+                break
+        else:
+            tox.reporter.error("cmd.exe cannot be found")
+            raise SystemExit(0)
+
+
+if tox.INFO.IS_WIN:
+    PopenInActivatedEnv = PopenInActivatedEnvWindows
+else:
+    PopenInActivatedEnv = PopenInActivatedEnvPosix
+
+
+@contextmanager
+def activate_env(venv, action=None):
+    """Run a command in a temporary activated anaconda env."""
+    # Backup popen before setting it with the one in an activated env.
+    if action is None:
+        initial_popen = venv.popen
+        venv.popen = PopenInActivatedEnv(venv, initial_popen)
+    else:
+        initial_popen = action.via_popen
+        action.via_popen = PopenInActivatedEnv(venv, initial_popen)
+
+    yield
+
+    # Revert popen to its initial value.
+    if action is None:
+        venv.popen = initial_popen
+    else:
+        action.via_popen = initial_popen

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -4,13 +4,14 @@ import re
 import shutil
 import subprocess
 import tempfile
-from contextlib import contextmanager
 
 import pluggy
 import py.path
 import tox
 from tox.config import DepConfig, DepOption, TestenvConfig
 from tox.venv import VirtualEnv
+
+from .env_activator import activate_env
 
 hookimpl = pluggy.HookimplMarker("tox")
 
@@ -50,44 +51,6 @@ def get_py_version(envconfig, action):
         version = result.decode("utf-8").strip()
 
     return "python={}".format(version)
-
-
-class CondaRunWrapper:
-    """A functor that execute a command via conda run.
-
-    It wraps popen so the command is executed in the context of an activated env.
-    """
-
-    CONDA_RUN_CMD_PREFIX = "{conda_exe} run --no-capture-output -p {envdir}"
-
-    def __init__(self, venv, popen):
-        self.__venv = venv
-        self.__popen = popen
-
-    def __call__(self, cmd_args, **kwargs):
-        conda_run_cmd_prefix = self.CONDA_RUN_CMD_PREFIX.format(
-            conda_exe=self.__venv.envconfig.conda_exe, envdir=self.__venv.envconfig.envdir
-        )
-        cmd_args = conda_run_cmd_prefix.split() + cmd_args
-        return self.__popen(cmd_args, **kwargs)
-
-
-@contextmanager
-def conda_run(venv, action=None):
-    """Run a command via conda run."""
-    if action is None:
-        initial_popen = venv.popen
-        venv.popen = CondaRunWrapper(venv, initial_popen)
-    else:
-        initial_popen = action.via_popen
-        action.via_popen = CondaRunWrapper(venv, initial_popen)
-
-    yield
-
-    if action is None:
-        venv.popen = initial_popen
-    else:
-        action.via_popen = initial_popen
 
 
 @hookimpl
@@ -298,7 +261,7 @@ def tox_testenv_install_deps(venv, action):
 
             venv.envconfig.deps.append(tox.config.DepConfig("-r{}".format(temp_req_filename)))
 
-    with conda_run(venv, action):
+    with activate_env(venv, action):
         tox.venv.tox_testenv_install_deps(venv=venv, action=action)
 
     # Restore the deps.
@@ -349,18 +312,18 @@ VirtualEnv._venv_lookup = venv_lookup
 
 @hookimpl(hookwrapper=True)
 def tox_runtest_pre(venv):
-    with conda_run(venv):
+    with activate_env(venv):
         yield
 
 
 @hookimpl
 def tox_runtest(venv, redirect):
-    with conda_run(venv):
+    with activate_env(venv):
         tox.venv.tox_runtest(venv, redirect)
     return True
 
 
 @hookimpl(hookwrapper=True)
 def tox_runtest_post(venv):
-    with conda_run(venv):
+    with activate_env(venv):
         yield

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -166,7 +166,7 @@ def find_conda():
         _exit_on_missing_conda()
 
     try:
-        subprocess.check_call([str(path), "-h"])
+        subprocess.run([str(path), "-h"], stdout=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         _exit_on_missing_conda()
 


### PR DESCRIPTION
Using `conda run` for running commands in an activated env has some issues:

- requires a quite recent conda version (4.9),
- a yet not reported issue with the last anaconda distribution on windows: `conda create -n foo python=3.8` then `conda run -n foo pip install wheel==0.36.0` fails.

This PR removes the need for using conda run and has been tested down to conda version 4.5.
