### PR TITLE
Improved change-detection for existing environments and install python when using env file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,10 +122,12 @@ section of configuration files:
 
 * ``conda_env``, which specifies a ``conda-env.yml`` file to create a base conda
   environment for the test. The ``conda-env.yml`` file is self-contained and
-  if the desired python version and conda channels to use is not given, the latest
-  python version (if needed) and default channels will be used. The above ``conda_deps``,
-  ``conda_channels``, and ``conda_spec`` arguments, if used in conjunction with
-  a ``conda-env.yml`` file, will be used to *update* the environment *after* the
+  if the desired conda channels to use are not given, the default channels will be used.
+  If the ``conda-env.yml`` specifies a python version it must be compatible with the ``basepython``
+  set for the tox env. A ``conda-env.yml`` specifying ``python>=3.8`` could for example be
+  used with ``basepython`` set to ``py38``, ``py39`` or ``py310``.
+  The above ``conda_deps``, ``conda_channels``, and ``conda_spec`` arguments, if used in
+  conjunction with a ``conda-env.yml`` file, will be used to *update* the environment *after* the
   initial environment creation.
 
 * ``conda_create_args``, which is used to pass arguments to the command ``conda create``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ruamel.yaml>=0.15.0
+    ruamel.yaml>=0.15.0,<0.18
     tox>=3.8.1,<4
 python_requires = >=3.5
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
 packages = find:
 install_requires =
     tox>=3.8.1,<4
+    ruamel.yaml>=0.11.14
 python_requires = >=3.5
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    tox>=3.8.1,<4
     ruamel.yaml>=0.11.14
+    tox>=3.8.1,<4
 python_requires = >=3.5
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ruamel.yaml>=0.11.14
+    ruamel.yaml>=0.15.0
     tox>=3.8.1,<4
 python_requires = >=3.5
 

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -286,6 +286,7 @@ def test_conda_env(tmpdir, newconfig, mocksession):
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
+    assert cmd[6].endswith(".yaml")
 
     yaml = YAML()
     tmp_env = yaml.load(Path(cmd[6]))
@@ -338,6 +339,7 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
+    assert cmd[6].endswith(".yaml")
 
     yaml = YAML()
     tmp_env = yaml.load(Path(cmd[6]))

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -282,6 +282,10 @@ def test_conda_env(tmpdir, newconfig, mocksession):
         def __exit__(self, exc_type, exc_value, traceback):
             TemporaryFileMock.checked = True
 
+            # We need to close the file before we can open it again in reading mode, or we will
+            # get permission denied on Windows
+            self.file.__exit__(exc_type, exc_value, traceback)
+
             yaml = YAML()
             tmp_env = yaml.load(Path(self.name))
             assert tmp_env["dependencies"][-1].startswith("python=")
@@ -348,6 +352,10 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     class TemporaryFileMock(tempfile._TemporaryFileWrapper):
         def __exit__(self, exc_type, exc_value, traceback):
             TemporaryFileMock.checked = True
+
+            # We need to close the file before we can open it again in reading mode, or we will
+            # get permission denied on Windows
+            self.file.__exit__(exc_type, exc_value, traceback)
 
             yaml = YAML()
             tmp_env = yaml.load(Path(self.name))

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -277,20 +277,14 @@ def test_conda_env(tmpdir, newconfig, mocksession):
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
     pcalls = mocksession._pcalls
-    assert len(pcalls) >= 2
-    call = pcalls[-2]
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
     cmd = call.args
     assert "conda" in os.path.split(cmd[0])[-1]
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert call.args[6].endswith("conda-env.yml")
-
-    call = pcalls[-1]
-    cmd = call.args
-    assert "conda" in os.path.split(cmd[0])[-1]
-    assert cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
-    assert cmd[6].startswith("python=")
 
 
 def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
@@ -331,20 +325,14 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
     pcalls = mocksession._pcalls
-    assert len(pcalls) >= 2
-    call = pcalls[-2]
+    assert len(pcalls) >= 1
+    call = pcalls[-1]
     cmd = call.args
     assert "conda" in os.path.split(cmd[0])[-1]
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert call.args[6].endswith("conda-env.yml")
-
-    call = pcalls[-1]
-    cmd = call.args
-    assert "conda" in os.path.split(cmd[0])[-1]
-    assert cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
-    assert cmd[6].startswith("python=")
 
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_install_deps(action=action, venv=venv)

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -277,14 +277,20 @@ def test_conda_env(tmpdir, newconfig, mocksession):
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
     pcalls = mocksession._pcalls
-    assert len(pcalls) >= 1
-    call = pcalls[-1]
+    assert len(pcalls) >= 2
+    call = pcalls[-2]
     cmd = call.args
     assert "conda" in os.path.split(cmd[0])[-1]
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert call.args[6].endswith("conda-env.yml")
+
+    call = pcalls[-1]
+    cmd = call.args
+    assert "conda" in os.path.split(cmd[0])[-1]
+    assert cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
+    assert cmd[6].startswith("python=")
 
 
 def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
@@ -325,14 +331,20 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
     pcalls = mocksession._pcalls
-    assert len(pcalls) >= 1
-    call = pcalls[-1]
+    assert len(pcalls) >= 2
+    call = pcalls[-2]
     cmd = call.args
     assert "conda" in os.path.split(cmd[0])[-1]
     assert cmd[1:4] == ["env", "create", "-p"]
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert call.args[6].endswith("conda-env.yml")
+
+    call = pcalls[-1]
+    cmd = call.args
+    assert "conda" in os.path.split(cmd[0])[-1]
+    assert cmd[1:6] == ["install", "--quiet", "--yes", "-p", venv.path]
+    assert cmd[6].startswith("python=")
 
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_install_deps(action=action, venv=venv)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,30 @@ def test_conda_deps(tmpdir, newconfig):
     assert "something" == config.envconfigs["py1"].conda_deps[1].name
 
 
+def test_conda_env_and_spec(tmpdir, newconfig):
+    config = newconfig(
+        [],
+        """
+        [tox]
+        toxworkdir = {}
+        [testenv:py1]
+        conda_env = conda_env.yaml
+        conda_spec = conda_spec.txt
+    """.format(
+            tmpdir
+        ),
+    )
+
+    assert len(config.envconfigs) == 1
+    assert config.envconfigs["py1"].conda_env == tmpdir / "conda_env.yaml"
+    assert config.envconfigs["py1"].conda_spec == tmpdir / "conda_spec.txt"
+    # Conda env and spec files get added to deps to allow tox to detect changes. Similar to conda_deps.
+    assert hasattr(config.envconfigs["py1"], "deps")
+    assert len(config.envconfigs["py1"].deps) == 2
+    assert any(dep.name == tmpdir / "conda_env.yaml" for dep in config.envconfigs["py1"].deps)
+    assert any(dep.name == tmpdir / "conda_spec.txt" for dep in config.envconfigs["py1"].deps)
+
+
 def test_no_conda_deps(tmpdir, newconfig):
     config = newconfig(
         [],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,7 +44,8 @@ def test_conda_env_and_spec(tmpdir, newconfig):
     assert len(config.envconfigs) == 1
     assert config.envconfigs["py1"].conda_env == tmpdir / "conda_env.yaml"
     assert config.envconfigs["py1"].conda_spec == tmpdir / "conda_spec.txt"
-    # Conda env and spec files get added to deps to allow tox to detect changes. Similar to conda_deps.
+    # Conda env and spec files get added to deps to allow tox to detect changes.
+    # Similar to conda_deps in the test above.
     assert hasattr(config.envconfigs["py1"], "deps")
     assert len(config.envconfigs["py1"].deps) == 2
     assert any(dep.name == tmpdir / "conda_env.yaml" for dep in config.envconfigs["py1"].deps)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ setenv =
     VIRTUALENV_DOWNLOAD = 0
 deps =
     pytest-timeout
+    ruamel.yaml>=0.15
     tox[testing]>=3.8.1,<4
 commands =
     pytest {posargs: \

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ setenv =
     VIRTUALENV_DOWNLOAD = 0
 deps =
     pytest-timeout
-    ruamel.yaml>=0.15
     tox[testing]>=3.8.1,<4
 commands =
     pytest {posargs: \

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -246,14 +246,14 @@ def tox_testenv_install_deps(venv, action):
     num_conda_deps = len(venv.envconfig.conda_deps)
     if venv.envconfig.conda_spec is not None:
         num_conda_deps += 1
-    if venv.envconfig.conda_env is not None:
-        num_conda_deps += 1
 
     if num_conda_deps > 0:
         install_conda_deps(venv, action, venv.path.dirpath(), venv.envconfig.envdir)
         # Account for the fact that we added the conda_deps to the deps list in
         # tox_configure (see comment there for rationale). We don't want them
         # to be present when we call pip install.
+        if venv.envconfig.conda_env is not None:
+            num_conda_deps += 1
         venv.envconfig.deps = venv.envconfig.deps[: -1 * num_conda_deps]
 
     with activate_env(venv, action):

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -151,7 +151,7 @@ def _run_conda_process(args, venv, action, cwd):
 
 
 @hookimpl
-def tox_testenv_create(venv, action, _test_leave_tmp_env=False):
+def tox_testenv_create(venv, action):
     tox.venv.cleanup_for_venv(venv)
     basepath = venv.path.dirpath()
 
@@ -167,22 +167,20 @@ def tox_testenv_create(venv, action, _test_leave_tmp_env=False):
         env_file = yaml.load(Path(venv.envconfig.conda_env))
         env_file["dependencies"].append(python)
 
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp_env:
+        with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp_env:
             yaml.dump(env_file, tmp_env)
 
-        args = [
-            venv.envconfig.conda_exe,
-            "env",
-            "create",
-            "-p",
-            envdir,
-            "--file",
-            tmp_env.name,
-        ]
+            args = [
+                venv.envconfig.conda_exe,
+                "env",
+                "create",
+                "-p",
+                envdir,
+                "--file",
+                tmp_env.name,
+            ]
 
-        _run_conda_process(args, venv, action, basepath)
-        if not _test_leave_tmp_env:
-            os.unlink(tmp_env.name)
+            _run_conda_process(args, venv, action, basepath)
     else:
         args = [venv.envconfig.conda_exe, "create", "--yes", "-p", envdir]
         for channel in venv.envconfig.conda_channels:

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -167,7 +167,7 @@ def tox_testenv_create(venv, action, _test_leave_tmp_env=False):
         env_file = yaml.load(Path(venv.envconfig.conda_env))
         env_file["dependencies"].append(python)
 
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_env:
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp_env:
             yaml.dump(env_file, tmp_env)
 
         args = [

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -255,7 +255,8 @@ def tox_testenv_install_deps(venv, action):
     # to be present when we call pip install.
     if venv.envconfig.conda_env is not None:
         num_conda_deps += 1
-    venv.envconfig.deps = venv.envconfig.deps[: -1 * num_conda_deps]
+    if num_conda_deps > 0:
+        venv.envconfig.deps = venv.envconfig.deps[:-num_conda_deps]
 
     with activate_env(venv, action):
         tox.venv.tox_testenv_install_deps(venv=venv, action=action)

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -249,12 +249,13 @@ def tox_testenv_install_deps(venv, action):
 
     if num_conda_deps > 0:
         install_conda_deps(venv, action, venv.path.dirpath(), venv.envconfig.envdir)
-        # Account for the fact that we added the conda_deps to the deps list in
-        # tox_configure (see comment there for rationale). We don't want them
-        # to be present when we call pip install.
-        if venv.envconfig.conda_env is not None:
-            num_conda_deps += 1
-        venv.envconfig.deps = venv.envconfig.deps[: -1 * num_conda_deps]
+
+    # Account for the fact that we added the conda_deps to the deps list in
+    # tox_configure (see comment there for rationale). We don't want them
+    # to be present when we call pip install.
+    if venv.envconfig.conda_env is not None:
+        num_conda_deps += 1
+    venv.envconfig.deps = venv.envconfig.deps[: -1 * num_conda_deps]
 
     with activate_env(venv, action):
         tox.venv.tox_testenv_install_deps(venv=venv, action=action)

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -3,13 +3,13 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pluggy
 import py.path
-from ruamel.yaml import YAML
-import tempfile
 import tox
+from ruamel.yaml import YAML
 from tox.config import DepConfig, DepOption, TestenvConfig
 from tox.venv import VirtualEnv
 


### PR DESCRIPTION
This PR has various improvements for the handling of conda env and spec files:
1. Tox will now detect changes to env and spec files and recreate the environment when changes are detected.
2. Python will be installed in the conda env if a env file is used. Previously python was only being installed when no env file is used. ~~This is done by first creating the env using the env file, then installing python to it.
This does not detect conflicts between env file and python version. Detecting conflicts, like it is done when not using an env file would require adding python to a temporary copy of the env file, which would require adding a yaml parser as a dependency to tox-conda, which is why I decided against it.~~ This is done by parsing the conda_env.yaml, adding python to the dependencies section and saving it as a temporary file.
