### PR TITLE
Fix relative paths in conda env not working

### DIFF
--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -281,6 +281,8 @@ def test_conda_env(tmpdir, newconfig, mocksession):
         with mocksession.newaction(venv.name, "getenv") as action:
             tox_testenv_create(action=action, venv=venv)
 
+    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml")
+
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     call = pcalls[-1]
@@ -290,8 +292,6 @@ def test_conda_env(tmpdir, newconfig, mocksession):
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert cmd[6] == str(mock_file().name)
-
-    mock_file.assert_any_call(suffix=".yaml")
 
     yaml = YAML()
     tmp_env = yaml.load(mock_open_to_string(mock_file))
@@ -338,6 +338,8 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
         with mocksession.newaction(venv.name, "getenv") as action:
             tox_testenv_create(action=action, venv=venv)
 
+    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml")
+
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     call = pcalls[-1]
@@ -347,8 +349,6 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
     assert venv.path == call.args[4]
     assert call.args[5].startswith("--file")
     assert cmd[6] == str(mock_file().name)
-
-    mock_file.assert_any_call(suffix=".yaml")
 
     yaml = YAML()
     tmp_env = yaml.load(mock_open_to_string(mock_file))

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -160,14 +160,17 @@ def tox_testenv_create(venv, action):
     python = get_py_version(venv.envconfig, action)
 
     if venv.envconfig.conda_env is not None:
+        env_path = Path(venv.envconfig.conda_env)
         # conda env create does not have a --channel argument nor does it take
         # dependencies specifications (e.g., python=3.8). These must all be specified
         # in the conda-env.yml file
         yaml = YAML()
-        env_file = yaml.load(Path(venv.envconfig.conda_env))
+        env_file = yaml.load(env_path)
         env_file["dependencies"].append(python)
 
-        with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp_env:
+        with tempfile.NamedTemporaryFile(
+            dir=env_path.parent, prefix="tox_conda_tmp", suffix=".yaml"
+        ) as tmp_env:
             yaml.dump(env_file, tmp_env)
 
             args = [


### PR DESCRIPTION
Fixes #143 

@tobiasraabe, could you confirm if this fixes your problem?

This now creates the temporary env file in the directory where the original env file is, therefor relative paths should work again.
The temporary file is automatically deleted again after conda finishes running.