### PR TITLE
fix-conda-temp-file-permission-error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args:
           - --py3-plus
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import pathlib
 from unittest.mock import mock_open, patch
 
 import tox
@@ -278,10 +279,12 @@ def test_conda_env(tmpdir, newconfig, mocksession):
 
     mock_file = mock_open()
     with patch("tox_conda.plugin.tempfile.NamedTemporaryFile", mock_file):
-        with mocksession.newaction(venv.name, "getenv") as action:
-            tox_testenv_create(action=action, venv=venv)
+        with patch.object(pathlib.Path, "unlink", autospec=True) as mock_unlink:
+            with mocksession.newaction(venv.name, "getenv") as action:
+                tox_testenv_create(action=action, venv=venv)
+                mock_unlink.assert_called_once
 
-    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml")
+    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml", delete=False)
 
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
@@ -335,10 +338,12 @@ def test_conda_env_and_spec(tmpdir, newconfig, mocksession):
 
     mock_file = mock_open()
     with patch("tox_conda.plugin.tempfile.NamedTemporaryFile", mock_file):
-        with mocksession.newaction(venv.name, "getenv") as action:
-            tox_testenv_create(action=action, venv=venv)
+        with patch.object(pathlib.Path, "unlink", autospec=True) as mock_unlink:
+            with mocksession.newaction(venv.name, "getenv") as action:
+                tox_testenv_create(action=action, venv=venv)
+                mock_unlink.assert_called_once
 
-    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml")
+    mock_file.assert_called_with(dir=tmpdir, prefix="tox_conda_tmp", suffix=".yaml", delete=False)
 
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1

--- a/tests/test_conda_env.py
+++ b/tests/test_conda_env.py
@@ -1,7 +1,7 @@
 import io
 import os
-import re
 import pathlib
+import re
 from unittest.mock import mock_open, patch
 
 import tox

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ depends =
 
 [testenv:pkg_meta]
 description = check that the long description is valid
-basepython = python3.9
+basepython = python3.10
 skip_install = true
 deps =
     build>=0.0.4

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -169,7 +169,10 @@ def tox_testenv_create(venv, action):
         env_file["dependencies"].append(python)
 
         tmp_env = tempfile.NamedTemporaryFile(
-            dir=env_path.parent, prefix="tox_conda_tmp", suffix=".yaml", delete=False,
+            dir=env_path.parent,
+            prefix="tox_conda_tmp",
+            suffix=".yaml",
+            delete=False,
         )
         yaml.dump(env_file, tmp_env)
 
@@ -185,7 +188,7 @@ def tox_testenv_create(venv, action):
         tmp_env.close()
         _run_conda_process(args, venv, action, basepath)
         Path(tmp_env.name).unlink()
-        
+
     else:
         args = [venv.envconfig.conda_exe, "create", "--yes", "-p", envdir]
         for channel in venv.envconfig.conda_channels:

--- a/tox_conda/plugin.py
+++ b/tox_conda/plugin.py
@@ -168,22 +168,24 @@ def tox_testenv_create(venv, action):
         env_file = yaml.load(env_path)
         env_file["dependencies"].append(python)
 
-        with tempfile.NamedTemporaryFile(
-            dir=env_path.parent, prefix="tox_conda_tmp", suffix=".yaml"
-        ) as tmp_env:
-            yaml.dump(env_file, tmp_env)
+        tmp_env = tempfile.NamedTemporaryFile(
+            dir=env_path.parent, prefix="tox_conda_tmp", suffix=".yaml", delete=False,
+        )
+        yaml.dump(env_file, tmp_env)
 
-            args = [
-                venv.envconfig.conda_exe,
-                "env",
-                "create",
-                "-p",
-                envdir,
-                "--file",
-                tmp_env.name,
-            ]
-
-            _run_conda_process(args, venv, action, basepath)
+        args = [
+            venv.envconfig.conda_exe,
+            "env",
+            "create",
+            "-p",
+            envdir,
+            "--file",
+            tmp_env.name,
+        ]
+        tmp_env.close()
+        _run_conda_process(args, venv, action, basepath)
+        Path(tmp_env.name).unlink()
+        
     else:
         args = [venv.envconfig.conda_exe, "create", "--yes", "-p", envdir]
         for channel in venv.envconfig.conda_channels:


### PR DESCRIPTION
On Windows OS, users are unable to run `_run_conda_process(args, venv, action, basepath)` within the `with tempfile.NamedTemporaryFile() context`. 

Slight replace with context with create the file, close it, run `_run_conda_process`, then remove the file.

Fixes #159 